### PR TITLE
send/sync bound fix. fixes #2

### DIFF
--- a/src/convec.rs
+++ b/src/convec.rs
@@ -13,8 +13,8 @@ pub struct ConVec<T> {
     allocations: [UnsafeCell<Vec<T>>; 64],
 }
 
-unsafe impl<T> Sync for ConVec<T> {}
-unsafe impl<T> Send for ConVec<T> {}
+unsafe impl<T: Send + Sync> Sync for ConVec<T> {}
+unsafe impl<T: Send> Send for ConVec<T> {}
 
 impl<T> ConVec<T> {
     pub fn new() -> Self {


### PR DESCRIPTION
Fixes bug reported in #2.

Impose correct Send/Sync bounds to prevent unsound usage at compile time.

Thank you for reviewing this PR :+1: 